### PR TITLE
zaki/added_native_picker_components

### DIFF
--- a/src/javascript/app_2/pages/trading/components/amount.jsx
+++ b/src/javascript/app_2/pages/trading/components/amount.jsx
@@ -11,6 +11,7 @@ const Amount = ({
     currencies_list,
     amount,
     onChange,
+    is_nativepicker,
 }) => (
         <fieldset>
             <div className='fieldset-header'>
@@ -25,6 +26,7 @@ const Amount = ({
                     value={basis}
                     name='basis'
                     onChange={onChange}
+                    is_nativepicker={is_nativepicker}
                 />
                 <InputField
                     type='number'
@@ -42,6 +44,7 @@ const Amount = ({
                     value={currency}
                     name='currency'
                     onChange={onChange}
+                    is_nativepicker={is_nativepicker}
                 />
             }
         </fieldset>

--- a/src/javascript/app_2/pages/trading/components/duration.jsx
+++ b/src/javascript/app_2/pages/trading/components/duration.jsx
@@ -12,6 +12,7 @@ const Duration = ({
     duration_units_list,
     server_time,
     onChange,
+    is_nativepicker,
 }) => (
         <fieldset>
             <ClockHeader className='row-1 col-100' time={server_time} header={localize('Trade Duration')} />
@@ -23,6 +24,7 @@ const Duration = ({
                 value={expiry_type}
                 name='expiry_type'
                 onChange={onChange}
+                is_nativepicker={is_nativepicker}
             />
 
             {expiry_type === 'duration' ?
@@ -39,6 +41,7 @@ const Duration = ({
                             value={duration_unit}
                             name='duration_unit'
                             onChange={onChange}
+                            is_nativepicker={is_nativepicker}
                         />
                     </div>
                 </React.Fragment> :

--- a/src/javascript/app_2/pages/trading/components/form/dropdown.jsx
+++ b/src/javascript/app_2/pages/trading/components/form/dropdown.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Select } from './native_pickers.jsx';
 
 class Dropdown extends React.PureComponent {
     constructor(props) {
@@ -68,45 +69,55 @@ class Dropdown extends React.PureComponent {
     }
 
     render() {
-        return (
-            <div
-                ref={this.setWrapperRef}
-                className={`dropdown-container ${this.props.className ? this.props.className : ''} ${this.state.is_list_visible ? 'show' : ''}`}>
+        if (!this.props.is_nativepicker) {
+            return (
                 <div
-                    className={`dropdown-display ${this.state.is_list_visible ? 'clicked': ''}`}
-                    onClick={this.handleVisibility}
-                    onBlur={this.handleVisibility}
-                >
-                    <span name={this.props.name} value={this.props.value}>
-                        {this.getDisplayText(this.props.list, this.props.value)}
-                    </span>
-                </div>
-                <span className='select-arrow' />
-                <div className='dropdown-list'>
-                    <div className='list-container'>
-                    { this.isOneLevel(this.props.list) ?
-                        <Items
-                            items={this.props.list}
-                            name={this.props.name}
-                            value={this.props.value}
-                            handleSelect={this.handleSelect}
-                            type={this.props.type || undefined}
-                        /> :
-                        Object.keys(this.props.list).map(key => (
-                            <React.Fragment key={key}>
-                                <div className='list-label'><span>{key}</span></div>
-                                <Items
-                                    items={this.props.list[key]}
-                                    name={this.props.name}
-                                    value={this.props.value}
-                                    handleSelect={this.handleSelect}
-                                />
-                            </React.Fragment>
-                        ))
-                    }
+                    ref={this.setWrapperRef}
+                    className={`dropdown-container ${this.props.className ? this.props.className : ''} ${this.state.is_list_visible ? 'show' : ''}`}>
+                    <div
+                        className={`dropdown-display ${this.state.is_list_visible ? 'clicked': ''}`}
+                        onClick={this.handleVisibility}
+                        onBlur={this.handleVisibility}
+                    >
+                        <span name={this.props.name} value={this.props.value}>
+                            {this.getDisplayText(this.props.list, this.props.value)}
+                        </span>
+                    </div>
+                    <span className='select-arrow' />
+                    <div className='dropdown-list'>
+                        <div className='list-container'>
+                        { this.isOneLevel(this.props.list) ?
+                            <Items
+                                items={this.props.list}
+                                name={this.props.name}
+                                value={this.props.value}
+                                handleSelect={this.handleSelect}
+                                type={this.props.type || undefined}
+                            /> :
+                            Object.keys(this.props.list).map(key => (
+                                <React.Fragment key={key}>
+                                    <div className='list-label'><span>{key}</span></div>
+                                    <Items
+                                        items={this.props.list[key]}
+                                        name={this.props.name}
+                                        value={this.props.value}
+                                        handleSelect={this.handleSelect}
+                                    />
+                                </React.Fragment>
+                            ))
+                        }
+                        </div>
                     </div>
                 </div>
-            </div>
+            );
+        }
+        return (
+            <Select
+                name={this.props.name}
+                value={this.props.value}
+                list={this.props.list}
+                onChange={this.props.onChange}
+            />
         );
     }
 }

--- a/src/javascript/app_2/pages/trading/components/form/native_pickers.jsx
+++ b/src/javascript/app_2/pages/trading/components/form/native_pickers.jsx
@@ -12,13 +12,13 @@ const Select = ({
               <option key={idx} value={item.value}>{item.text}</option>
           ))
         :
-        Object.keys(list).map((group, idx) => (
-            <React.Fragment key={idx}>
-                <optgroup key={idx} label={group}></optgroup>
-                {list[group].map(v => (
-                    <option key={v} value={v}>{v}</option>
+        Object.keys(list).map(key => (
+            <React.Fragment key={key}>
+                <optgroup label={key}></optgroup>
+                {list[key].map((item, idx) => (
+                    <option key={idx} value={item.value}>{item.text}</option>
                 ))}
-           </React.Fragment>
+            </React.Fragment>
         ))}
     </select>
 );

--- a/src/javascript/app_2/pages/trading/components/form/native_pickers.jsx
+++ b/src/javascript/app_2/pages/trading/components/form/native_pickers.jsx
@@ -1,0 +1,45 @@
+import React from 'react';
+
+const Select = ({
+    name,
+    value,
+    list,
+    onChange,
+}) => (
+    <select name={name} value={value} onChange={onChange}>
+        {Array.isArray(list) ?
+          list.map((item, idx) => (
+              <option key={idx} value={item.value}>{item.text}</option>
+          ))
+        :
+        Object.keys(list).map((group, idx) => (
+            <React.Fragment key={idx}>
+                <optgroup key={idx} label={group}></optgroup>
+                {list[group].map(v => (
+                    <option key={v} value={v}>{v}</option>
+                ))}
+           </React.Fragment>
+        ))}
+    </select>
+);
+
+const DatePicker = ({
+    name,
+    onChange,
+}) => (
+    // TO-DO: Return amount of days instead of time
+    <input type='date' name={name} onChange={onChange} />
+);
+
+const TimePicker = ({
+    name,
+    onChange,
+}) => (
+    <input type='time' name={name} onChange={onChange} />
+);
+
+module.exports = {
+    Select,
+    DatePicker,
+    TimePicker,
+};

--- a/src/javascript/app_2/pages/trading/components/start_date.jsx
+++ b/src/javascript/app_2/pages/trading/components/start_date.jsx
@@ -10,6 +10,7 @@ const StartDate = ({
     start_time,
     server_time,
     onChange,
+    is_nativepicker,
 }) => (
     <fieldset>
         <ClockHeader time={server_time} header={localize('Start time')} />
@@ -19,6 +20,7 @@ const StartDate = ({
             list={start_dates_list}
             onChange={onChange}
             type='date'
+            is_nativepicker={is_nativepicker}
         />
         {start_date !== 'now' &&
             <React.Fragment>

--- a/src/sass/app_2/trading.scss
+++ b/src/sass/app_2/trading.scss
@@ -10,6 +10,7 @@
             width: 100%;
             font-size: 1rem;
             height: 32px;
+            align-self: center;
         }
         .clock-header, .fieldset-header {
             height: 1.5rem;

--- a/src/sass/app_2/trading.scss
+++ b/src/sass/app_2/trading.scss
@@ -9,8 +9,12 @@
         input, select {
             width: 100%;
             font-size: 1rem;
+            font-weight: 300;
             height: 32px;
             align-self: center;
+        }
+        select {
+            margin: 8px 0;
         }
         .clock-header, .fieldset-header {
             height: 1.5rem;


### PR DESCRIPTION
Changelog
---
-  Added native form picker fallback components for mobile usage.
- Implemented native select picker for `Dropdown` component.

Usage
---
- Pass `is_nativepicker` props to `<Dropdown />` component.
- Example below:
```
<Dropdown 
  list={list} 
  name={name} 
  value={value} 
  is_nativepicker 
/>`